### PR TITLE
Fix Frontend Build

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,5 +26,10 @@
   },
   "engines": {
     "node": "23"
+  },
+  "targets": {
+    "default": {
+      "context": "browser"
+    }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request
I broke the build in the last merge.  This fixes it by telling `parcel` that we want to target the browser and not Node.