### PR TITLE
Use Build Reusable GitHub Action in our Deploy Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ on:
   workflow_call:
     outputs:
       BACKEND_ARTIFACT_NAME:
-        description: asdf
-        value: dogcow
+        description: Unique name of the uploaded backend artifact
+        value: ${{ jobs.build-backend.outputs.BACKEND_ARTIFACT_NAME }}
       FRONTEND_ARTIFACT_NAME:
-        description: asdf
-        value: dogcow
+        description: Unique name of the uploaded frontend artifact
+        value: ${{ jobs.build-frontend.outputs.FRONTEND_ARTIFACT_NAME }}
 
 
 permissions:
@@ -22,6 +22,10 @@ jobs:
   build-backend:
     name: Build Backend
     runs-on: ubuntu-latest
+    env:
+      BACKEND_ARTIFACT_NAME: backend
+    outputs:
+      BACKEND_ARTIFACT_NAME: ${{ env.BACKEND_ARTIFACT_NAME }}
 
     steps:
 
@@ -43,7 +47,7 @@ jobs:
       - name: Store Backend Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: backend
+          name: ${{ env.BACKEND_ARTIFACT_NAME }}
           path: backend/dist/lambda.zip
           overwrite: true
 
@@ -51,6 +55,10 @@ jobs:
   build-frontend:
     name: Build Frontend
     runs-on: ubuntu-latest
+    env:
+      FRONTEND_ARTIFACT_NAME: frontend
+    outputs:
+      FRONTEND_ARTIFACT_NAME: ${{ env.FRONTEND_ARTIFACT_NAME }}
 
     steps:
 
@@ -71,6 +79,6 @@ jobs:
       - name: Store Frontend Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: frontend
+          name: ${{ env.FRONTEND_ARTIFACT_NAME }}
           path: ui/dist/
           overwrite: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,13 @@ name: Build
 
 on:
   workflow_call:
+    outputs:
+      BACKEND_ARTIFACT_NAME:
+        description: asdf
+        value: dogcow
+      FRONTEND_ARTIFACT_NAME:
+        description: asdf
+        value: dogcow
 
 
 permissions:
@@ -33,6 +40,13 @@ jobs:
       - working-directory: ./backend/
         run: uv run build.py
 
+      - name: Store Backend Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend
+          path: backend/dist/lambda.zip
+          overwrite: true
+
 
   build-frontend:
     name: Build Frontend
@@ -53,3 +67,10 @@ jobs:
 
       - working-directory: ./ui/
         run: npm run build
+
+      - name: Store Frontend Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend
+          path: ui/dist/
+          overwrite: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Restore Backend Artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ jobs.build.outputs.BACKEND_ARTIFACT_NAME }}
+          name: ${{ needs.build.outputs.BACKEND_ARTIFACT_NAME }}
           path: backend/dist/lambda.zip
 
       - name: Restore Frontend Artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ jobs.build.outputs.FRONTEND_ARTIFACT_NAME }}
+          name: ${{ needs.build.outputs.FRONTEND_ARTIFACT_NAME }}
           path: ui/dist/
 
       - working-directory: ./iac/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,18 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
 
+      - name: Restore Backend Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend
+          path: backend/dist/lambda.zip
+
+      - name: Restore Frontend Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend
+          path: ui/dist/
+
       - working-directory: ./iac/
         run: terraform init -backend-config="key=terraform_state_gsa_dev.tfstate"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,9 +14,16 @@ permissions:
 
 jobs:
 
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    needs:
+      - build
     steps:
 
       - uses: actions/checkout@v4
@@ -27,31 +34,6 @@ jobs:
           aws-region: us-east-1
 
       - uses: hashicorp/setup-terraform@v3
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: ./backend/.python-version
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: ./backend/uv.lock
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ./ui/package.json
-          cache: npm
-          cache-dependency-path: ./ui/package-lock.json
-
-      - working-directory: ./backend/
-        run: uv run build.py
-
-      - working-directory: ./ui/
-        run: npm ci
-
-      - working-directory: ./ui/
-        run: npm run build
 
       - working-directory: ./iac/
         run: terraform init -backend-config="key=terraform_state_gsa_dev.tfstate"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.BACKEND_ARTIFACT_NAME }}
-          path: backend/dist/lambda.zip
+          path: backend/dist/
 
       - name: Restore Frontend Artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,13 +38,13 @@ jobs:
       - name: Restore Backend Artifact
         uses: actions/download-artifact@v4
         with:
-          name: backend
+          name: ${{ jobs.build.outputs.BACKEND_ARTIFACT_NAME }}
           path: backend/dist/lambda.zip
 
       - name: Restore Frontend Artifact
         uses: actions/download-artifact@v4
         with:
-          name: frontend
+          name: ${{ jobs.build.outputs.FRONTEND_ARTIFACT_NAME }}
           path: ui/dist/
 
       - working-directory: ./iac/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   id-token: write
+  pull-requests: write
   contents: read
 
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

The Continuous Deployment GitHub action now uses the reusable Build GitHub action, so we don't duplicate this logic across different GitHub actions.