### PR TITLE
Determine Document Type

### DIFF
--- a/backend/detect_document_type.py
+++ b/backend/detect_document_type.py
@@ -2,6 +2,6 @@ from src.external.ocr.textract import Textract
 
 if __name__ == "__main__":
     scanner = Textract()
-    result = scanner.detect_document_type("s3://document-extractor-gsa-dev-documents/test_1099.jpg")
+    result = scanner.detect_document_type("s3://document-extractor-gsa-dev-documents/test_dd214.jpg")
 
     print(f"Document type is {result}")

--- a/backend/detect_document_type.py
+++ b/backend/detect_document_type.py
@@ -2,6 +2,6 @@ from src.external.ocr.textract import Textract
 
 if __name__ == "__main__":
     scanner = Textract()
-    result = scanner.detect_document_type("s3://document-extractor-gsa-dev-documents/test_ws.jpg")
+    result = scanner.detect_document_type("s3://document-extractor-gsa-dev-documents/test_1099.jpg")
 
     print(f"Document type is {result}")

--- a/backend/detect_document_type.py
+++ b/backend/detect_document_type.py
@@ -1,0 +1,7 @@
+from src.external.ocr.textract import Textract
+
+if __name__ == "__main__":
+    scanner = Textract()
+    result = scanner.detect_document_type("s3://document-extractor-gsa-dev-documents/test_ws.jpg")
+
+    print(f"Document type is {result}")

--- a/backend/src/external/lambda/text_extractor.py
+++ b/backend/src/external/lambda/text_extractor.py
@@ -33,8 +33,19 @@ def lambda_handler(event, context):
             ),
         }
 
+    ocr_engine = Textract()
+
     try:
-        ocr_engine = Textract()
+        document_type = ocr_engine.detect_document_type(f"s3://{bucket_name}/{document_key}")
+    except OcrException as e:
+        exception_message = f"Failed to detect the document type of s3://{bucket_name}/{document_key}: {e}"
+        print(exception_message)
+        return {
+            "statusCode": 500,
+            "body": json.dumps(exception_message),
+        }
+
+    try:
         extracted_data = ocr_engine.scan(f"s3://{bucket_name}/{document_key}")
     except OcrException as e:
         exception_message = f"Failed to extract text from S3 object s3://{bucket_name}/{document_key}: {e}"
@@ -52,6 +63,7 @@ def lambda_handler(event, context):
                 {
                     "document_key": document_key,
                     "extracted_data": extracted_data,
+                    "document_type": document_type,
                 }
             ),
         )

--- a/backend/src/external/ocr/textract.py
+++ b/backend/src/external/ocr/textract.py
@@ -21,7 +21,7 @@ class Textract(Ocr):
             document_type = None
 
             for block in response.get("Blocks", []):
-                if block.get("BlockType") != "WORD":
+                if block.get("BlockType") != "WORD" and block.get("BlockType") != "LINE":
                     continue
 
                 if block.get("Text") == "W-2":
@@ -30,7 +30,7 @@ class Textract(Ocr):
                 elif block.get("Text") == "1099-NEC":
                     document_type = "1099-NEC"
                     break
-                elif block.get("Text") == "DD214":
+                elif block.get("Text").startswith("DD FORM 214"):
                     document_type = "DD214"
                     break
 

--- a/backend/src/external/ocr/textract.py
+++ b/backend/src/external/ocr/textract.py
@@ -11,27 +11,31 @@ class Textract(Ocr):
         self.textract_client = boto3.client("textract")
 
     def detect_document_type(self, s3_url: str) -> str | None:
-        bucket_name, object_key = self._parse_s3_url(s3_url)
+        try:
+            bucket_name, object_key = self._parse_s3_url(s3_url)
 
-        response = self.textract_client.detect_document_text(
-            Document={"S3Object": {"Bucket": bucket_name, "Name": object_key}}
-        )
+            response = self.textract_client.detect_document_text(
+                Document={"S3Object": {"Bucket": bucket_name, "Name": object_key}}
+            )
 
-        document_type = None
+            document_type = None
 
-        for block in response.get("Blocks", []):
-            if block.get("BlockType") != "WORD":
-                continue
+            for block in response.get("Blocks", []):
+                if block.get("BlockType") != "WORD":
+                    continue
 
-            if block.get("Text") == "W-2":
-                document_type = "W2"
-                break
-            elif block.get("Text") == "1099":
-                document_type = "1099"
-                break
-            elif block.get("Text") == "DD214":
-                document_type = "DD214"
-                break
+                if block.get("Text") == "W-2":
+                    document_type = "W2"
+                    break
+                elif block.get("Text") == "1099":
+                    document_type = "1099"
+                    break
+                elif block.get("Text") == "DD214":
+                    document_type = "DD214"
+                    break
+
+        except Exception as e:
+            raise OcrException(f"Unable to detect the document type of {s3_url}") from e
 
         return document_type
 

--- a/backend/src/external/ocr/textract.py
+++ b/backend/src/external/ocr/textract.py
@@ -10,6 +10,31 @@ class Textract(Ocr):
     def __init__(self) -> None:
         self.textract_client = boto3.client("textract")
 
+    def detect_document_type(self, s3_url: str) -> str | None:
+        bucket_name, object_key = self._parse_s3_url(s3_url)
+
+        response = self.textract_client.detect_document_text(
+            Document={"S3Object": {"Bucket": bucket_name, "Name": object_key}}
+        )
+
+        document_type = None
+
+        for block in response.get("Blocks", []):
+            if block.get("BlockType") != "WORD":
+                continue
+
+            if block.get("Text") == "W-2":
+                document_type = "W2"
+                break
+            elif block.get("Text") == "1099":
+                document_type = "1099"
+                break
+            elif block.get("Text") == "DD214":
+                document_type = "DD214"
+                break
+
+        return document_type
+
     def _parse_s3_url(self, s3_url: str) -> tuple[str, str]:
         parsed_url = parse.urlparse(s3_url)
 

--- a/backend/src/external/ocr/textract.py
+++ b/backend/src/external/ocr/textract.py
@@ -35,7 +35,7 @@ class Textract(Ocr):
                     break
 
         except Exception as e:
-            raise OcrException(f"Unable to detect the document type of {s3_url}") from e
+            raise OcrException(f"Failure while trying to detect the document type of {s3_url}") from e
 
         return document_type
 

--- a/backend/src/external/ocr/textract.py
+++ b/backend/src/external/ocr/textract.py
@@ -27,8 +27,8 @@ class Textract(Ocr):
                 if block.get("Text") == "W-2":
                     document_type = "W2"
                     break
-                elif block.get("Text") == "1099":
-                    document_type = "1099"
+                elif block.get("Text") == "1099-NEC":
+                    document_type = "1099-NEC"
                     break
                 elif block.get("Text") == "DD214":
                     document_type = "DD214"

--- a/backend/src/ocr/ocr.py
+++ b/backend/src/ocr/ocr.py
@@ -3,5 +3,9 @@ from abc import ABC, abstractmethod
 
 class Ocr(ABC):
     @abstractmethod
+    def detect_document_type(self, s3_url: str) -> str | None:
+        pass
+
+    @abstractmethod
     def scan(self, s3_url: str) -> dict[str, dict[str, str | float]]:
         pass


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Classifies the document uploaded as a W2, 1099-NEC, or DD214.  Right now the text to look for and the resulting document type are hardcoded.  A future PR will make this more flexible.  Perhaps in my draft #89 PR.

This PR also pipes the document type to the other steps, so `document_type` is now filled in when calling the read ReST API.

For #71.