### PR TITLE
Change h4 to h2 and h3 for proper heading hierarchy on download page

### DIFF
--- a/ui/src/pages/DownloadPage.js
+++ b/ui/src/pages/DownloadPage.js
@@ -158,9 +158,9 @@ export default function DownloadPage({ signOut }) {
             <li className="usa-card tablet:grid-col-6 widescreen:grid-col-4">
               <div className="usa-card__container">
                 <div className="usa-card__header">
-                  <h4 className="usa-card__heading font-body-md">
+                  <h2 className="usa-card__heading font-body-md">
                     File download
-                  </h4>
+                  </h2>
                 </div>
                 <div className="usa-card__body">
                   {/* Start radio button section  */}
@@ -223,7 +223,7 @@ export default function DownloadPage({ signOut }) {
         </form>
         <div id="preview-section">
           <h2 id="preview-section-title">File Preview</h2>
-          <h4 id="preview-section-file-name">File name</h4>
+          <h3 id="preview-section-file-name">File name</h3>
           <div>{displayPreviewTable()}</div>
         </div>
       </div>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

<!-- Provide a high-level list of changes included in this pull request: -->

- Change h4 to h2 and h3 for proper heading hierarchy on download page

## Security considerations

<!-- Note the any security considerations here, or note why there are none -->

-

<!--

  Please note, this repository belongs to an Open Source project and that code
  changes, issues, Pull Requests, etc. are all visible to the public.  Please
  be mindful of how what we do and say may reflect on ourselves, our team,
  and those with whom we interact.

-->
