### PR TITLE
Read the Status of a Document

### DIFF
--- a/backend/src/external/aws/lambdas/get_extracted_document.py
+++ b/backend/src/external/aws/lambdas/get_extracted_document.py
@@ -32,9 +32,10 @@ def lambda_handler(event, context):
             }
 
         response = {
+            "status": document_info["status"],
             "document_id": document_id,
-            "document_key": document_info["document_url"],
-            "document_type": document_info["document_type"],
+            "document_key": document_info.get("document_url"),
+            "document_type": document_info.get("document_type"),
             "extracted_data": document_info.get("extracted_data", {}),
             "signed_url": storage_access_url,
             "base64_encoded_file": base64.b64encode(document_data).decode("utf-8"),

--- a/ui/src/pages/VerifyPage.js
+++ b/ui/src/pages/VerifyPage.js
@@ -12,6 +12,9 @@ export default function VerifyPage({ signOut }) {
   const navigate = useNavigate();
 
   async function pollApiRequest(attempts = 30, delay = 2000) {
+    // Helper function to sleep for the specified delay
+    const sleep = () => new Promise((resolve) => setTimeout(resolve, delay));
+
     for (let i = 0; i < attempts; i++) {
       try {
         const response = await authorizedFetch(`/api/document/${documentId}`, {
@@ -27,6 +30,7 @@ export default function VerifyPage({ signOut }) {
           return;
         } else if (!response.ok) {
           console.warn(`Attempt ${i + 1} failed: ${response.statusText}`);
+          await sleep();
           continue;
         }
 
@@ -36,6 +40,7 @@ export default function VerifyPage({ signOut }) {
           console.info(
             `Attempt ${i + 1} is not complete.  Trying again in a little bit.`
           );
+          await sleep();
           continue;
         }
 
@@ -45,9 +50,8 @@ export default function VerifyPage({ signOut }) {
         return;
       } catch (error) {
         console.error(`Attempt ${i + 1} failed:`, error);
+        await sleep();
       }
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     console.error('Attempt failed after max attempts');

--- a/ui/src/pages/VerifyPage.js
+++ b/ui/src/pages/VerifyPage.js
@@ -21,26 +21,35 @@ export default function VerifyPage({ signOut }) {
           },
         });
 
-        if (response.ok) {
-          const result = await response.json(); // parse response
-
-          setResponseData(result); // store API data in state
-          setLoading(false); // stop loading when data is received
-          setError(false); // clear any previous errors
-          return;
-        } else if (response.status === 401 || response.status === 403) {
+        if (response.status === 401 || response.status === 403) {
           alert('You are no longer signed in!  Please sign in again.');
           signOut();
           return;
-        } else {
+        } else if (!response.ok) {
           console.warn(`Attempt ${i + 1} failed: ${response.statusText}`);
+          continue;
         }
+
+        const result = await response.json(); // parse response
+
+        if (result.status !== 'complete') {
+          console.info(
+            `Attempt ${i + 1} is not complete.  Trying again in a little bit.`
+          );
+          continue;
+        }
+
+        setResponseData(result); // store API data in state
+        setLoading(false); // stop loading when data is received
+        setError(false); // clear any previous errors
+        return;
       } catch (error) {
         console.error(`Attempt ${i + 1} failed:`, error);
       }
 
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
+
     console.error('Attempt failed after max attempts');
     setLoading(false);
     setError(true);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Backend improvement to send back status for the get request.  Updated the frontend to continue to query for a finished document when the `status` is not `complete`.

Towards #157.